### PR TITLE
WIP: refactoring ideas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "anyhow",
+ "async-trait",
  "chrono",
  "chrono-tz",
  "convert_case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ serde = "1.0.0"
 serde_json = "1.0.0"
 sqlx = { version = "0.4.0", features = [ "chrono", "mysql", "runtime-actix-native-tls"] }
 thiserror = "1.0.0"
+async-trait = "0.1"

--- a/src/uuid/model/attachment.rs
+++ b/src/uuid/model/attachment.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use crate::uuid::model::{IdAccessible, UuidError};
+use async_trait::async_trait;
 use database_layer_actix::format_alias;
 use serde::Serialize;
 use sqlx::MySqlPool;
@@ -11,8 +12,9 @@ pub struct Attachment {
     pub alias: String,
 }
 
-impl Attachment {
-    pub async fn find_by_id(id: i32, pool: &MySqlPool) -> Result<Attachment> {
+#[async_trait]
+impl IdAccessible for Attachment {
+    async fn find_by_id(id: i32, pool: &MySqlPool) -> Result<Self, UuidError> {
         let attachment = sqlx::query!(
             r#"
                 SELECT u.trashed, f.name
@@ -35,7 +37,9 @@ impl Attachment {
             ),
         })
     }
+}
 
+impl Attachment {
     pub fn get_context() -> Option<String> {
         return Some(String::from("attachment"));
     }

--- a/src/uuid/model/blog_post.rs
+++ b/src/uuid/model/blog_post.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
+use crate::uuid::model::{IdAccessible, UuidError};
+use async_trait::async_trait;
 use database_layer_actix::format_alias;
 use serde::Serialize;
-use sqlx::MySqlPool;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -11,8 +11,9 @@ pub struct BlogPost {
     pub alias: String,
 }
 
-impl BlogPost {
-    pub async fn find_by_id(id: i32, pool: &MySqlPool) -> Result<BlogPost> {
+#[async_trait]
+impl IdAccessible for BlogPost {
+    async fn find_by_id(id: i32, pool: &sqlx::MySqlPool) -> Result<Self, UuidError> {
         let blog = sqlx::query!(
             r#"
                 SELECT u.trashed, b.title
@@ -34,7 +35,9 @@ impl BlogPost {
             ),
         })
     }
+}
 
+impl BlogPost {
     pub fn get_context() -> Option<String> {
         return Some(String::from("blog"));
     }

--- a/src/uuid/model/mod.rs
+++ b/src/uuid/model/mod.rs
@@ -8,5 +8,50 @@ mod page_revision;
 mod taxonomy_term;
 mod user;
 mod uuid;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
-pub use self::uuid::{Uuid, UuidError};
+pub use self::uuid::Uuid;
+use async_trait::async_trait;
+
+#[derive(Error, Debug)]
+pub enum UuidError {
+    #[error("`Database error {inner:?}` occured.")]
+    DatabaseError { inner: sqlx::Error },
+    #[error("`{discriminator:?}` is not a valid uuid type.")]
+    InvalidDiscriminator { discriminator: String },
+    #[error("UUID not found in database.")]
+    NotFound,
+}
+
+impl From<sqlx::Error> for UuidError {
+    fn from(error: sqlx::Error) -> Self {
+        match error {
+            sqlx::Error::RowNotFound => UuidError::NotFound,
+            e => UuidError::DatabaseError { inner: e },
+        }
+    }
+}
+
+/// Interface for accessing resources that can be identified
+/// Through a UUID.
+#[async_trait]
+trait IdAccessible {
+    async fn find_by_id(id: i32, pool: &sqlx::MySqlPool) -> Result<Self, UuidError>
+    where
+        Self: Sized;
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum ObjectType {
+    Attachment,
+    BlogPost,
+    Comment,
+    Entity,
+    EntityRevision,
+    Page,
+    PageRevision,
+    TaxonomyTerm,
+    User,
+}

--- a/src/uuid/model/page_revision.rs
+++ b/src/uuid/model/page_revision.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
+use crate::uuid::model::{IdAccessible, UuidError};
+use async_trait::async_trait;
 use database_layer_actix::{format_alias, format_datetime};
 use serde::Serialize;
-use sqlx::MySqlPool;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -18,8 +18,9 @@ pub struct PageRevision {
     pub repository_id: i32,
 }
 
-impl PageRevision {
-    pub async fn find_by_id(id: i32, pool: &MySqlPool) -> Result<PageRevision> {
+#[async_trait]
+impl IdAccessible for PageRevision {
+    async fn find_by_id(id: i32, pool: &sqlx::MySqlPool) -> Result<Self, UuidError> {
         let revision = sqlx::query!(
             r#"
                 SELECT u.trashed, r.title, r.content, r.date, r.author_id, r.page_repository_id

--- a/src/uuid/model/user.rs
+++ b/src/uuid/model/user.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
+use crate::uuid::model::{IdAccessible, UuidError};
+use async_trait::async_trait;
 use database_layer_actix::{format_alias, format_datetime};
 use serde::Serialize;
-use sqlx::MySqlPool;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -17,8 +17,9 @@ pub struct User {
     pub description: Option<String>,
 }
 
-impl User {
-    pub async fn find_by_id(id: i32, pool: &MySqlPool) -> Result<User> {
+#[async_trait]
+impl IdAccessible for User {
+    async fn find_by_id(id: i32, pool: &sqlx::MySqlPool) -> Result<Self, UuidError> {
         let user = sqlx::query!(
             r#"
                 SELECT trashed, username, date, last_login, description
@@ -41,7 +42,8 @@ impl User {
             description: user.description,
         })
     }
-
+}
+impl User {
     pub fn get_context() -> Option<String> {
         return Some(String::from("user"));
     }

--- a/src/uuid/model/uuid.rs
+++ b/src/uuid/model/uuid.rs
@@ -1,7 +1,5 @@
-use anyhow::Result;
 use serde::Serialize;
 use sqlx::MySqlPool;
-use thiserror::Error;
 
 use crate::uuid::model::attachment::Attachment;
 use crate::uuid::model::blog_post::BlogPost;
@@ -12,7 +10,11 @@ use crate::uuid::model::page::Page;
 use crate::uuid::model::page_revision::PageRevision;
 use crate::uuid::model::taxonomy_term::TaxonomyTerm;
 use crate::uuid::model::user::User;
+use crate::uuid::model::{IdAccessible, ObjectType, UuidError};
 
+//FIXME: I think the name Uuid is misleading,
+// since the object does not represent a uuid,
+// but a resource identified by a uuid.
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum Uuid {
@@ -27,65 +29,65 @@ pub enum Uuid {
     User(User),
 }
 
+impl std::str::FromStr for ObjectType {
+    type Err = UuidError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_value(serde_json::value::Value::String(s.into())).map_err(|_e| {
+            UuidError::InvalidDiscriminator {
+                discriminator: s.into(),
+            }
+        })
+    }
+}
+
 impl Uuid {
-    pub async fn find_by_id(id: i32, pool: &MySqlPool) -> Result<Uuid> {
+    pub async fn find_by_id(id: i32, pool: &MySqlPool) -> Result<Uuid, UuidError> {
         let uuid = sqlx::query!(r#"SELECT discriminator FROM uuid WHERE id = ?"#, id)
             .fetch_one(pool)
-            .await
-            .map_err(|e| match e {
-                sqlx::Error::RowNotFound => anyhow::Error::new(UuidError::NotFound { id }),
-                e => anyhow::Error::new(e),
-            })?;
-        match uuid.discriminator.as_str() {
-            "attachment" => Ok(Uuid::Attachment(Attachment::find_by_id(id, pool).await?)),
-            "blogPost" => Ok(Uuid::BlogPost(BlogPost::find_by_id(id, pool).await?)),
-            "comment" => Ok(Uuid::Comment(Comment::find_by_id(id, pool).await?)),
-            "entity" => Ok(Uuid::Entity(Entity::find_by_id(id, pool).await?)),
-            "entityRevision" => Ok(Uuid::EntityRevision(
+            .await?;
+
+        match uuid.discriminator.as_str().parse()? {
+            ObjectType::Attachment => Ok(Uuid::Attachment(Attachment::find_by_id(id, pool).await?)),
+            ObjectType::BlogPost => Ok(Uuid::BlogPost(BlogPost::find_by_id(id, pool).await?)),
+            ObjectType::Comment => Ok(Uuid::Comment(Comment::find_by_id(id, pool).await?)),
+            ObjectType::Entity => Ok(Uuid::Entity(Entity::find_by_id(id, pool).await?)),
+            ObjectType::EntityRevision => Ok(Uuid::EntityRevision(
                 EntityRevision::find_by_id(id, pool).await?,
             )),
-            "page" => Ok(Uuid::Page(Page::find_by_id(id, pool).await?)),
-            "pageRevision" => Ok(Uuid::PageRevision(
+            ObjectType::Page => Ok(Uuid::Page(Page::find_by_id(id, pool).await?)),
+            ObjectType::PageRevision => Ok(Uuid::PageRevision(
                 PageRevision::find_by_id(id, pool).await?,
             )),
-            "taxonomyTerm" => Ok(Uuid::TaxonomyTerm(
+            ObjectType::TaxonomyTerm => Ok(Uuid::TaxonomyTerm(
                 TaxonomyTerm::find_by_id(id, pool).await?,
             )),
-            "user" => Ok(Uuid::User(User::find_by_id(id, pool).await?)),
-            _ => Err(anyhow::Error::new(UuidError::UnsupportedDiscriminator {
-                id,
-                discriminator: uuid.discriminator,
-            })),
+            ObjectType::User => Ok(Uuid::User(User::find_by_id(id, pool).await?)),
         }
     }
 
     pub async fn find_context_by_id(
         id: i32,
         pool: &MySqlPool,
-    ) -> Result<Option<String>, sqlx::Error> {
+    ) -> Result<Option<String>, UuidError> {
         let uuid = sqlx::query!(r#"SELECT discriminator FROM uuid WHERE id = ?"#, id)
             .fetch_one(pool)
             .await?;
-        match uuid.discriminator.as_str() {
-            "attachment" => Ok(Attachment::get_context()),
-            "blogPost" => Ok(BlogPost::get_context()),
+
+        match uuid.discriminator.as_str().parse()? {
+            ObjectType::Attachment => Ok(Attachment::get_context()),
+            ObjectType::BlogPost => Ok(BlogPost::get_context()),
             // This is done intentionally to avoid a recursive `async fn` and because this is not needed.
-            "comment" => Ok(None),
-            "entity" => Entity::find_canonical_subject_by_id(id, pool).await,
-            "entityRevision" => EntityRevision::find_canonical_subject_by_id(id, pool).await,
-            "page" => Ok(None),         // TODO:
-            "pageRevision" => Ok(None), // TODO:
-            "taxonomyTerm" => TaxonomyTerm::find_canonical_subject_by_id(id, pool).await,
-            "user" => Ok(User::get_context()),
-            _ => Ok(None),
+            //FIXME: what is done intentionally?
+            ObjectType::Comment => Ok(None),
+            ObjectType::Entity => Entity::find_canonical_subject_by_id(id, pool).await,
+            ObjectType::EntityRevision => {
+                EntityRevision::find_canonical_subject_by_id(id, pool).await
+            }
+            ObjectType::Page => Ok(None),         // TODO:
+            ObjectType::PageRevision => Ok(None), // TODO:
+            ObjectType::TaxonomyTerm => TaxonomyTerm::find_canonical_subject_by_id(id, pool).await,
+            ObjectType::User => Ok(User::get_context()),
         }
     }
-}
-
-#[derive(Error, Debug)]
-pub enum UuidError {
-    #[error("UUID {id:?} can't be fetched because is `{discriminator:?}` is not supported.")]
-    UnsupportedDiscriminator { id: i32, discriminator: String },
-    #[error("UUID {id:?} not found.")]
-    NotFound { id: i32 },
 }

--- a/src/uuid/routes.rs
+++ b/src/uuid/routes.rs
@@ -10,12 +10,14 @@ async fn find(id: web::Path<i32>, db_pool: web::Data<MySqlPool>) -> impl Respond
         Ok(uuid) => HttpResponse::Ok().json(uuid),
         Err(e) => {
             println!("UUID {} failed: {:?}", id, e);
-            match e.downcast_ref::<UuidError>() {
-                Some(UuidError::UnsupportedDiscriminator { .. }) => {
+            match e {
+                UuidError::InvalidDiscriminator { .. } => {
                     HttpResponse::BadRequest().json(None::<String>)
                 }
-                Some(UuidError::NotFound { .. }) => HttpResponse::NotFound().json(None::<String>),
-                _ => HttpResponse::BadRequest().json(None::<String>),
+                UuidError::NotFound => HttpResponse::NotFound().json(None::<String>),
+                UuidError::DatabaseError { .. } => {
+                    HttpResponse::InternalServerError().json(None::<String>)
+                }
             }
         }
     }


### PR DESCRIPTION
Refactor UuuidError types: With a library-like submodule like uuid, I think it's better to use  a consistent error type that describes the errors relevant to this module. With anyhow, it is not immediately visible which kinds of errors can occur and we cannot exhaustively match on them to check that all possible error cases have been handled meaningfully.

Also used serde to parse the uuid descriminator into a variant which can be exhaustively matched on. That way, only the ObjectType variant has to be extended and unhandled variants cause compile errors.