### PR TITLE
POST /thread/comment-thread

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1725,16 +1725,6 @@
       ]
     }
   },
-  "d712fad9b2e9f86649f77d3052392963e2695801da403174b86def97b6e977c6": {
-    "query": "\n            INSERT INTO subscription (uuid_id, user_id, notify_mailman, date)\n                SELECT ?, ?, ?, ?\n                WHERE NOT EXISTS\n                (SELECT id FROM subscription WHERE uuid_id = ? AND user_id = ?)\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 6
-      },
-      "nullable": []
-    }
-  },
   "d96a45d0d014aece234428d2b3deeb6740e956e7c1d0f380d2bdbc258180d5aa": {
     "query": "\n                INSERT INTO notification (user_id, date, email)\n                    VALUES (?, ?, ?)\n            ",
     "describe": {
@@ -1793,6 +1783,16 @@
       "nullable": [
         false
       ]
+    }
+  },
+  "e301aa5d422549cc37a921cfb491915ffe39e03b48bfc5dd7d2c6316a3fca185": {
+    "query": "\n                INSERT INTO subscription (uuid_id, user_id, notify_mailman, date)\n                    VALUES (?, ?, ?, ?)\n                    ON DUPLICATE KEY UPDATE notify_mailman = ?\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 5
+      },
+      "nullable": []
     }
   },
   "e48ab97ec5329aa75500b78dd7d88f030b6aeb92b4ec5fa207dc15217e8b89f9": {

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -367,6 +367,16 @@
       ]
     }
   },
+  "240528d5b3a13de5585272c5c6b4a684c4ca77a3df12dd92fece7b748b422f00": {
+    "query": "\n                INSERT INTO event_parameter (log_id, name_id)\n                    SELECT ?, id\n                    FROM event_parameter_name\n                    WHERE name = ?\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 2
+      },
+      "nullable": []
+    }
+  },
   "2594f7eb0db4993eb684ae6fdf173a8999df485653a8544733a6ce29da94842d": {
     "query": "\n                SELECT t.name, u.trashed, r.date, r.author_id, r.repository_id\n                    FROM entity_revision r\n                    JOIN uuid u ON u.id = r.id\n                    JOIN entity e ON e.id = r.repository_id\n                    JOIN type t ON t.id = e.type_id\n                    WHERE r.id = ?\n            ",
     "describe": {
@@ -937,6 +947,44 @@
       "nullable": []
     }
   },
+  "59220da9f5e4677a6fdc380eca9b95923728d0efd09277eb85290b3b4aafa118": {
+    "query": "\n                SELECT instance_id, archived\n                    FROM comment\n                    WHERE id = ?\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "instance_id",
+          "type_info": {
+            "type": "Long",
+            "flags": {
+              "bits": 4105
+            },
+            "char_set": 63,
+            "max_size": 11
+          }
+        },
+        {
+          "ordinal": 1,
+          "name": "archived",
+          "type_info": {
+            "type": "Tiny",
+            "flags": {
+              "bits": 1
+            },
+            "char_set": 63,
+            "max_size": 1
+          }
+        }
+      ],
+      "parameters": {
+        "Right": 1
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
   "65d605e2dbfb889b8efc8300283a96aae8696bb8f61aab612e652bc765211d30": {
     "query": "\n                INSERT INTO notification_event (notification_id, event_log_id)\n                    SELECT LAST_INSERT_ID(), ?\n            ",
     "describe": {
@@ -970,6 +1018,26 @@
       "nullable": [
         false
       ]
+    }
+  },
+  "719654ca360621d4b33c2fd42bfec51fc21059a00d5b9f23eb56e3992c4a25d4": {
+    "query": "\n                INSERT INTO comment (id, date, archived, title, content, uuid_id, parent_id, author_id, instance_id )\n                    VALUES (LAST_INSERT_ID(), ?, 0, NULL, ?, NULL, ?, ?, ?)\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 5
+      },
+      "nullable": []
+    }
+  },
+  "769713eded2a80cb23fd93a3767bc1aa4cbc7446e97f4f87d595e922fd143841": {
+    "query": "\n                INSERT INTO event_log (actor_id, event_id, uuid_id, instance_id, date)\n                    SELECT ?, id, ?, ?, ?\n                    FROM event\n                    WHERE name = ?\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 5
+      },
+      "nullable": []
     }
   },
   "778d1aadfabd36aae4aabf449a61958b23a6f7f4b8c25844adcdd064acf7681a": {
@@ -1043,6 +1111,16 @@
       "nullable": [
         false
       ]
+    }
+  },
+  "87b99c353a3ccda694aaef3e4bd9d122313e7293997b7903d333327296a1118f": {
+    "query": "\n                INSERT INTO uuid (trashed, discriminator)\n                    VALUES (0, 'comment')\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 0
+      },
+      "nullable": []
     }
   },
   "911ea66921a64de401503189cf88681dfd600d01b1992a7de141668b1c93c371": {
@@ -1267,6 +1345,16 @@
       "columns": [],
       "parameters": {
         "Right": 3
+      },
+      "nullable": []
+    }
+  },
+  "b0cb5a20c4692bf60fdce29596049f4150b5531c1f97d3482a63daf7e5c9ea11": {
+    "query": "\n                INSERT INTO event_parameter_uuid (uuid_id, event_parameter_id)\n                    VALUES (? , ?)\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 2
       },
       "nullable": []
     }
@@ -1635,6 +1723,16 @@
         false,
         false
       ]
+    }
+  },
+  "d712fad9b2e9f86649f77d3052392963e2695801da403174b86def97b6e977c6": {
+    "query": "\n            INSERT INTO subscription (uuid_id, user_id, notify_mailman, date)\n                SELECT ?, ?, ?, ?\n                WHERE NOT EXISTS\n                (SELECT id FROM subscription WHERE uuid_id = ? AND user_id = ?)\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 6
+      },
+      "nullable": []
     }
   },
   "d96a45d0d014aece234428d2b3deeb6740e956e7c1d0f380d2bdbc258180d5aa": {

--- a/src/event/model/create_comment.rs
+++ b/src/event/model/create_comment.rs
@@ -1,9 +1,11 @@
+use serde::Serialize;
 use std::convert::TryFrom;
 
-use serde::Serialize;
-
-use super::abstract_event::AbstractEvent;
-use super::EventError;
+use super::event_type::EventType;
+use crate::database::Executor;
+use crate::datetime::DateTime;
+use crate::event::{AbstractEvent, Event, EventError};
+use crate::notifications::{Notifications, NotificationsError};
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -23,5 +25,148 @@ impl TryFrom<&AbstractEvent> for CreateCommentEvent {
             thread_id,
             comment_id,
         })
+    }
+}
+
+pub struct CreateCommentEventPayload {
+    __typename: EventType,
+    raw_typename: String,
+    actor_id: i32,
+    object_id: i32,
+    instance_id: i32,
+    uuid_parameter: i32,
+}
+
+impl CreateCommentEventPayload {
+    pub fn new(thread_id: i32, object_id: i32, actor_id: i32, instance_id: i32) -> Self {
+        let raw_typename = "discussion/comment/create".to_string();
+
+        CreateCommentEventPayload {
+            __typename: EventType::CreateComment,
+            raw_typename,
+            actor_id,
+            object_id,
+            instance_id,
+            uuid_parameter: thread_id,
+        }
+    }
+
+    pub async fn save<'a, E>(&self, executor: E) -> Result<Event, EventError>
+    where
+        E: Executor<'a>,
+    {
+        let mut transaction = executor.begin().await?;
+
+        // insert event_log
+        sqlx::query!(
+            r#"
+                INSERT INTO event_log (actor_id, event_id, uuid_id, instance_id, date)
+                    SELECT ?, id, ?, ?, ?
+                    FROM event
+                    WHERE name = ?
+            "#,
+            self.actor_id,
+            self.object_id,
+            self.instance_id,
+            DateTime::now(),
+            self.raw_typename,
+        )
+        .execute(&mut transaction)
+        .await?;
+        let value = sqlx::query!(r#"SELECT LAST_INSERT_ID() as id"#)
+            .fetch_one(&mut transaction)
+            .await?;
+        let event_log_id = value.id as i32;
+
+        // insert event_parameter
+        sqlx::query!(
+            r#"
+                INSERT INTO event_parameter ( log_id , name_id )
+                    SELECT ?, id
+                    FROM event_parameter_name
+                    WHERE name = ?
+            "#,
+            event_log_id,
+            "discussion"
+        )
+        .execute(&mut transaction)
+        .await?;
+
+        let value = sqlx::query!(r#"SELECT LAST_INSERT_ID() as id"#)
+            .fetch_one(&mut transaction)
+            .await?;
+        let parameter_id = value.id;
+
+        // insert event_parameter_uuid
+        sqlx::query!(
+            r#"
+                INSERT INTO event_parameter_uuid ( uuid_id, event_parameter_id )
+                    VALUES ( ? , ? )
+            "#,
+            self.uuid_parameter,
+            parameter_id
+        )
+        .execute(&mut transaction)
+        .await?;
+
+        let event = Event::fetch_via_transaction(event_log_id, &mut transaction).await?;
+
+        Notifications::create_notifications(&event, &mut transaction)
+            .await
+            .map_err(|error| match error {
+                NotificationsError::DatabaseError { inner } => EventError::from(inner),
+            })?;
+
+        transaction.commit().await?;
+
+        Ok(event)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Duration;
+
+    use super::{CreateCommentEvent, CreateCommentEventPayload};
+    use crate::create_database_pool;
+    use crate::datetime::DateTime;
+    use crate::event::{AbstractEvent, ConcreteEvent, Event};
+
+    #[actix_rt::test]
+    async fn create_comment() {
+        let pool = create_database_pool().await.unwrap();
+        let mut transaction = pool.begin().await.unwrap();
+
+        let set_thread_state_event = CreateCommentEventPayload::new(16740, 18932, 10, 1);
+
+        let event = set_thread_state_event.save(&mut transaction).await.unwrap();
+        let persisted_event =
+            Event::fetch_via_transaction(event.abstract_event.id, &mut transaction)
+                .await
+                .unwrap();
+
+        assert_eq!(event, persisted_event);
+
+        if let Event {
+            abstract_event:
+                AbstractEvent {
+                    actor_id: 10,
+                    object_id: 18932,
+                    date,
+                    uuid_parameters,
+                    ..
+                },
+            concrete_event:
+                ConcreteEvent::CreateComment(CreateCommentEvent {
+                    thread_id: 16740,
+                    comment_id: 18932,
+                }),
+        } = event
+        {
+            assert_eq!(uuid_parameters.get(&"discussion").unwrap(), 16740);
+            assert!(DateTime::now().signed_duration_since(date) < Duration::minutes(1))
+        } else {
+            panic!("Event does not fulfill assertions: {:?}", event)
+        }
     }
 }

--- a/src/event/model/create_comment.rs
+++ b/src/event/model/create_comment.rs
@@ -1,5 +1,6 @@
-use serde::Serialize;
 use std::convert::TryFrom;
+
+use serde::Serialize;
 
 use super::event_type::EventType;
 use crate::database::Executor;
@@ -34,7 +35,7 @@ pub struct CreateCommentEventPayload {
     actor_id: i32,
     object_id: i32,
     instance_id: i32,
-    uuid_parameter: i32,
+    thread_id: i32,
 }
 
 impl CreateCommentEventPayload {
@@ -47,7 +48,7 @@ impl CreateCommentEventPayload {
             actor_id,
             object_id,
             instance_id,
-            uuid_parameter: thread_id,
+            thread_id,
         }
     }
 
@@ -81,7 +82,7 @@ impl CreateCommentEventPayload {
         // insert event_parameter
         sqlx::query!(
             r#"
-                INSERT INTO event_parameter ( log_id , name_id )
+                INSERT INTO event_parameter (log_id, name_id)
                     SELECT ?, id
                     FROM event_parameter_name
                     WHERE name = ?
@@ -100,10 +101,10 @@ impl CreateCommentEventPayload {
         // insert event_parameter_uuid
         sqlx::query!(
             r#"
-                INSERT INTO event_parameter_uuid ( uuid_id, event_parameter_id )
-                    VALUES ( ? , ? )
+                INSERT INTO event_parameter_uuid (uuid_id, event_parameter_id)
+                    VALUES (? , ?)
             "#,
-            self.uuid_parameter,
+            self.thread_id,
             parameter_id
         )
         .execute(&mut transaction)

--- a/src/event/model/create_comment.rs
+++ b/src/event/model/create_comment.rs
@@ -164,7 +164,7 @@ mod tests {
                 }),
         } = event
         {
-            assert_eq!(uuid_parameters.get(&"discussion").unwrap(), 16740);
+            assert_eq!(uuid_parameters.get("discussion").unwrap(), 16740);
             assert!(DateTime::now().signed_duration_since(date) < Duration::minutes(1))
         } else {
             panic!("Event does not fulfill assertions: {:?}", event)

--- a/src/event/model/mod.rs
+++ b/src/event/model/mod.rs
@@ -42,7 +42,7 @@ pub enum EventError {
     InvalidInstance,
     #[error("Event cannot be fetched because a required field is missing.")]
     MissingRequiredField,
-    #[error("Event does not exist.")]
+    #[error("Event cannot be fetched because it does not exist.")]
     NotFound,
 }
 

--- a/src/threads/model.rs
+++ b/src/threads/model.rs
@@ -147,11 +147,11 @@ pub struct ThreadCommentThreadPayload {
 
 #[derive(Error, Debug)]
 pub enum ThreadCommentThreadError {
-    #[error("Comment could not be saved because of a database error: {inner:?}.")]
+    #[error("Comment cannot be saved because of a database error: {inner:?}.")]
     DatabaseError { inner: sqlx::Error },
-    #[error("Comment could not be saved because thread is archived")]
+    #[error("Comment cannot be saved because thread is archived.")]
     ThreadArchivedError,
-    #[error("Comment could not be saved because of a database error: {inner:?}.")]
+    #[error("Comment cannot be saved because of an event error: {inner:?}.")]
     EventError { inner: EventError },
 }
 

--- a/src/threads/routes.rs
+++ b/src/threads/routes.rs
@@ -54,13 +54,13 @@ async fn comment_thread(
             println!("/thread/comment-thread: {:?}", e);
             match e {
                 ThreadCommentThreadError::DatabaseError { .. } => {
-                    HttpResponse::InternalServerError().json(None::<String>)
+                    HttpResponse::InternalServerError().finish()
                 }
                 ThreadCommentThreadError::ThreadArchivedError { .. } => {
-                    HttpResponse::InternalServerError().json(None::<String>)
+                    HttpResponse::InternalServerError().finish()
                 }
                 ThreadCommentThreadError::EventError { .. } => {
-                    HttpResponse::InternalServerError().json(None::<String>)
+                    HttpResponse::InternalServerError().finish()
                 }
             }
         }

--- a/src/threads/routes.rs
+++ b/src/threads/routes.rs
@@ -1,7 +1,10 @@
 use actix_web::{get, post, web, HttpResponse, Responder};
 use sqlx::MySqlPool;
 
-use super::model::{ThreadSetArchiveError, ThreadSetArchivePayload, Threads, ThreadsError};
+use super::model::{
+    ThreadCommentThreadError, ThreadCommentThreadPayload, ThreadSetArchiveError,
+    ThreadSetArchivePayload, Threads, ThreadsError,
+};
 
 #[get("/threads/{id}")]
 async fn threads(id: web::Path<i32>, db_pool: web::Data<MySqlPool>) -> impl Responder {
@@ -40,7 +43,29 @@ async fn set_archive(
     }
 }
 
+#[post("/thread/comment-thread")]
+async fn comment_thread(
+    payload: web::Json<ThreadCommentThreadPayload>,
+    db_pool: web::Data<MySqlPool>,
+) -> impl Responder {
+    match Threads::comment_thread(payload.into_inner(), db_pool.get_ref()).await {
+        Ok(_) => HttpResponse::Ok().finish(),
+        Err(e) => {
+            println!("/thread/comment-thread: {:?}", e);
+            match e {
+                ThreadCommentThreadError::DatabaseError { .. } => {
+                    HttpResponse::InternalServerError().json(None::<String>)
+                }
+                ThreadCommentThreadError::EventError { .. } => {
+                    HttpResponse::InternalServerError().json(None::<String>)
+                }
+            }
+        }
+    }
+}
+
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(threads);
     cfg.service(set_archive);
+    cfg.service(comment_thread);
 }

--- a/src/threads/routes.rs
+++ b/src/threads/routes.rs
@@ -56,6 +56,9 @@ async fn comment_thread(
                 ThreadCommentThreadError::DatabaseError { .. } => {
                     HttpResponse::InternalServerError().json(None::<String>)
                 }
+                ThreadCommentThreadError::ThreadArchivedError { .. } => {
+                    HttpResponse::InternalServerError().json(None::<String>)
+                }
                 ThreadCommentThreadError::EventError { .. } => {
                     HttpResponse::InternalServerError().json(None::<String>)
                 }

--- a/src/uuid/mod.rs
+++ b/src/uuid/mod.rs
@@ -1,5 +1,5 @@
 pub use messages::UuidMessage;
-pub use model::{Uuid, UuidError, UuidFetcher};
+pub use model::*;
 pub use routes::init;
 
 mod messages;

--- a/src/uuid/model/comment.rs
+++ b/src/uuid/model/comment.rs
@@ -8,7 +8,7 @@ use crate::database::Executor;
 use crate::datetime::DateTime;
 use crate::format_alias;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Comment {
     #[serde(rename(serialize = "__typename"))]

--- a/src/uuid/model/entity/abstract_entity.rs
+++ b/src/uuid/model/entity/abstract_entity.rs
@@ -8,7 +8,7 @@ use super::UuidError;
 use crate::datetime::DateTime;
 use crate::instance::Instance;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AbstractEntity {
     #[serde(rename(serialize = "__typename"))]
@@ -22,7 +22,7 @@ pub struct AbstractEntity {
     pub revision_ids: Vec<i32>,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub enum EntityType {
     Applet,

--- a/src/uuid/model/entity/mod.rs
+++ b/src/uuid/model/entity/mod.rs
@@ -12,7 +12,7 @@ use crate::format_alias;
 
 mod abstract_entity;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct Entity {
     #[serde(flatten)]
     pub abstract_entity: AbstractEntity,
@@ -20,7 +20,7 @@ pub struct Entity {
     pub concrete_entity: ConcreteEntity,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum ConcreteEntity {
     Generic,
@@ -32,38 +32,38 @@ pub enum ConcreteEntity {
     Solution(Solution),
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Course {
     page_ids: Vec<i32>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CoursePage {
     parent_id: i32,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExerciseGroup {
     exercise_ids: Vec<i32>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Exercise {
     solution_id: Option<i32>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupedExercise {
     parent_id: i32,
     solution_id: Option<i32>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Solution {
     parent_id: i32,

--- a/src/uuid/model/entity_revision/abstract_entity_revision.rs
+++ b/src/uuid/model/entity_revision/abstract_entity_revision.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::UuidError;
 use crate::datetime::DateTime;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AbstractEntityRevision {
     #[serde(rename(serialize = "__typename"))]
@@ -19,7 +19,7 @@ pub struct AbstractEntityRevision {
     pub fields: EntityRevisionFields,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub enum EntityRevisionType {
     #[serde(rename(serialize = "AppletRevision"))]
@@ -62,6 +62,7 @@ impl std::str::FromStr for EntityRevisionType {
     }
 }
 
+#[derive(Debug)]
 pub struct EntityRevisionFields(pub HashMap<String, String>);
 
 impl EntityRevisionFields {

--- a/src/uuid/model/entity_revision/applet_revision.rs
+++ b/src/uuid/model/entity_revision/applet_revision.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::abstract_entity_revision::AbstractEntityRevision;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppletRevision {
     url: String,

--- a/src/uuid/model/entity_revision/article_revision.rs
+++ b/src/uuid/model/entity_revision/article_revision.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::abstract_entity_revision::AbstractEntityRevision;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ArticleRevision {
     title: String,

--- a/src/uuid/model/entity_revision/course_page_revision.rs
+++ b/src/uuid/model/entity_revision/course_page_revision.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::abstract_entity_revision::AbstractEntityRevision;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CoursePageRevision {
     title: String,

--- a/src/uuid/model/entity_revision/course_revision.rs
+++ b/src/uuid/model/entity_revision/course_revision.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::abstract_entity_revision::AbstractEntityRevision;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CourseRevision {
     title: String,

--- a/src/uuid/model/entity_revision/event_revision.rs
+++ b/src/uuid/model/entity_revision/event_revision.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::abstract_entity_revision::AbstractEntityRevision;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventRevision {
     title: String,

--- a/src/uuid/model/entity_revision/generic_entity_revision.rs
+++ b/src/uuid/model/entity_revision/generic_entity_revision.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::abstract_entity_revision::AbstractEntityRevision;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GenericRevision {
     content: String,

--- a/src/uuid/model/entity_revision/mod.rs
+++ b/src/uuid/model/entity_revision/mod.rs
@@ -25,7 +25,7 @@ mod event_revision;
 mod generic_entity_revision;
 mod video_revision;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct EntityRevision {
     #[serde(flatten)]
     pub abstract_entity_revision: AbstractEntityRevision,
@@ -33,7 +33,7 @@ pub struct EntityRevision {
     pub concrete_entity_revision: ConcreteEntityRevision,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum ConcreteEntityRevision {
     Generic(GenericRevision),

--- a/src/uuid/model/entity_revision/video_revision.rs
+++ b/src/uuid/model/entity_revision/video_revision.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use super::abstract_entity_revision::AbstractEntityRevision;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VideoRevision {
     url: String,

--- a/src/uuid/model/mod.rs
+++ b/src/uuid/model/mod.rs
@@ -1,6 +1,13 @@
-pub use uuid::{
-    ConcreteUuid, SetUuidStateError, SetUuidStatePayload, Uuid, UuidError, UuidFetcher,
-};
+pub use attachment::*;
+pub use blog_post::*;
+pub use comment::*;
+pub use entity::*;
+pub use entity_revision::*;
+pub use page::*;
+pub use page_revision::*;
+pub use taxonomy_term::*;
+pub use user::*;
+pub use uuid::*;
 
 mod attachment;
 mod blog_post;

--- a/src/uuid/model/page.rs
+++ b/src/uuid/model/page.rs
@@ -9,7 +9,7 @@ use crate::datetime::DateTime;
 use crate::format_alias;
 use crate::instance::Instance;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Page {
     #[serde(rename(serialize = "__typename"))]

--- a/src/uuid/model/page_revision.rs
+++ b/src/uuid/model/page_revision.rs
@@ -7,7 +7,7 @@ use crate::database::Executor;
 use crate::datetime::DateTime;
 use crate::format_alias;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PageRevision {
     #[serde(rename(serialize = "__typename"))]

--- a/src/uuid/model/taxonomy_term.rs
+++ b/src/uuid/model/taxonomy_term.rs
@@ -9,7 +9,7 @@ use crate::database::Executor;
 use crate::format_alias;
 use crate::instance::Instance;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaxonomyTerm {
     #[serde(rename(serialize = "__typename"))]

--- a/src/uuid/model/user.rs
+++ b/src/uuid/model/user.rs
@@ -7,7 +7,7 @@ use crate::database::Executor;
 use crate::datetime::DateTime;
 use crate::format_alias;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct User {
     #[serde(rename(serialize = "__typename"))]

--- a/src/uuid/model/uuid.rs
+++ b/src/uuid/model/uuid.rs
@@ -13,7 +13,7 @@ use super::{
     taxonomy_term::TaxonomyTerm, user::User,
 };
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct Uuid {
     pub id: i32,
     pub trashed: bool,
@@ -22,7 +22,7 @@ pub struct Uuid {
     pub concrete_uuid: ConcreteUuid,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum ConcreteUuid {
     Attachment,


### PR DESCRIPTION

----
**Actual queries legacy sends when adding comment.** 

Maybe helpful?
``` sql
START TRANSACTION

INSERT INTO uuid (trashed, discriminator) 
    VALUES (0, 'comment')

INSERT INTO comment ( id , date , archived , title , content , uuid_id , parent_id , author_id , instance_id )
    VALUES ( 35610 , '2021-01-29 02:26:19' , 0 , NULL , 'XANTWORTX' , NULL , 35609 , 1 , 1 )

INSERT INTO event_log ( date , actor_id , event_id , uuid_id , instance_id )
    VALUES ( '2021-01-29 02:26:20' , 1 , 9 , 35610 , 1 )
    
INSERT INTO event_parameter ( log_id , name_id )
    VALUES ( 86593 , 5 )
    
INSERT INTO event_parameter_uuid ( event_parameter_id , uuid_id )
    VALUES ( 70043 , 35609 )

COMMIT
```