### PR TITLE
SubscriptionChangeMutation

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1065,6 +1065,16 @@
       "nullable": []
     }
   },
+  "72988b124c9f33d66c499a89625eef7388b981b0428ab123bba4808b11651b41": {
+    "query": "DELETE FROM subscription WHERE uuid_id = ? AND user_id = ?",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 2
+      },
+      "nullable": []
+    }
+  },
   "769713eded2a80cb23fd93a3767bc1aa4cbc7446e97f4f87d595e922fd143841": {
     "query": "\n                INSERT INTO event_log (actor_id, event_id, uuid_id, instance_id, date)\n                    SELECT ?, id, ?, ?, ?\n                    FROM event\n                    WHERE name = ?\n            ",
     "describe": {

--- a/src/subscription/model.rs
+++ b/src/subscription/model.rs
@@ -207,8 +207,6 @@ impl Subscription {
     }
 }
 
-// TODO: add tests
-
 #[cfg(test)]
 mod tests {
     use crate::create_database_pool;

--- a/src/subscription/model.rs
+++ b/src/subscription/model.rs
@@ -195,7 +195,7 @@ impl Subscription {
                 send_email: payload.send_email,
             };
 
-            if payload.subscribe == true {
+            if payload.subscribe {
                 subscription.save(&mut transaction).await?;
             } else {
                 subscription.remove(&mut transaction).await?;

--- a/src/thread/model.rs
+++ b/src/thread/model.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use crate::database::Executor;
 use crate::datetime::DateTime;
 use crate::event::{CreateCommentEventPayload, EventError, SetThreadStateEventPayload};
-use crate::subscription::{Subscription, SubscriptionsError};
+use crate::subscription::{Subscription, SubscriptionChangeError};
 use crate::uuid::{Uuid, UuidError, UuidFetcher};
 
 #[derive(Serialize)]
@@ -257,7 +257,7 @@ impl Threads {
                     .save(&mut transaction)
                     .await
                     .map_err(|error| match error {
-                        SubscriptionsError::DatabaseError { inner } => EventError::from(inner),
+                        SubscriptionChangeError::DatabaseError { inner } => EventError::from(inner),
                     })?;
             }
         }
@@ -398,7 +398,7 @@ impl Threads {
                 .save(&mut transaction)
                 .await
                 .map_err(|error| match error {
-                    SubscriptionsError::DatabaseError { inner } => EventError::from(inner),
+                    SubscriptionChangeError::DatabaseError { inner } => EventError::from(inner),
                 })?;
         }
 


### PR DESCRIPTION
Draft for a mutation to add, update and remove subscriptions.

Notes:
- Did not add a route, since we likely change to messages
- Feel free to change the naming (and everything ;)
- slightly preferred to have only one message for all actions, but could also be split up (would maybe split it up for the graphql mutations?)