### PR TITLE
Small improvements

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -310,7 +310,7 @@
           "type_info": {
             "type": "Blob",
             "flags": {
-              "bits": 4121
+              "bits": 4113
             },
             "char_set": 224,
             "max_size": 4294967295
@@ -563,26 +563,6 @@
       ]
     }
   },
-  "3dc81c4f5e6a706b90116e28d1c7365697b1fb39bea538ee9005194e7d07282b": {
-    "query": "\n                        UPDATE uuid\n                            SET trashed = true\n                            WHERE id = ?\n                    ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": []
-    }
-  },
-  "40b8240c7dcab061ae6b38b169366923a24f07408a7c8f3dc94cf57af746733b": {
-    "query": "\n                    UPDATE uuid\n                        SET trashed = ?\n                        WHERE id = ?\n                ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 2
-      },
-      "nullable": []
-    }
-  },
   "436603084c0bc754c6d6baa29d1eb0d64f1ee26047a4b905585949e5ea544b15": {
     "query": "\n                SELECT trashed, username, date, last_login, description\n                    FROM user\n                    JOIN uuid ON user.id = uuid.id\n                    WHERE user.id = ?\n            ",
     "describe": {
@@ -753,7 +733,7 @@
           "type_info": {
             "type": "Blob",
             "flags": {
-              "bits": 24
+              "bits": 16
             },
             "char_set": 224,
             "max_size": 262140
@@ -1278,6 +1258,16 @@
       ]
     }
   },
+  "95cd88b4c06459122c191536fbef5c1c71a523fbf84a008593af1002721218d3": {
+    "query": "UPDATE uuid SET trashed = ? WHERE id = ?",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 2
+      },
+      "nullable": []
+    }
+  },
   "a400f2b325f4baa03878fd49187085fb2b95d0ca886494a2fca05f1ec65b7ed1": {
     "query": "SELECT repository_id FROM entity_revision WHERE id = ?",
     "describe": {
@@ -1385,7 +1375,7 @@
           "type_info": {
             "type": "Blob",
             "flags": {
-              "bits": 4120
+              "bits": 4112
             },
             "char_set": 224,
             "max_size": 4294967295
@@ -1397,7 +1387,7 @@
           "type_info": {
             "type": "Blob",
             "flags": {
-              "bits": 4120
+              "bits": 4112
             },
             "char_set": 224,
             "max_size": 4294967295
@@ -1502,16 +1492,6 @@
       "nullable": [
         false
       ]
-    }
-  },
-  "b6a8193e70c6a299cb9776625431dbba75019893b9cae04bc627507988dd4882": {
-    "query": "\n                        UPDATE uuid\n                            SET trashed = false\n                            WHERE id = ?\n                    ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": []
     }
   },
   "befb2d78ae7737e9d6e6a667301a984576cd5c451682394635e9e6c61b1b9669": {
@@ -2020,7 +2000,7 @@
           "type_info": {
             "type": "Blob",
             "flags": {
-              "bits": 4121
+              "bits": 4113
             },
             "char_set": 224,
             "max_size": 4294967295

--- a/src/uuid/model/entity/mod.rs
+++ b/src/uuid/model/entity/mod.rs
@@ -694,6 +694,25 @@ mod tests {
     }
 
     #[actix_rt::test]
+    async fn checkout_revision_sets_trashed_flag_to_false() {
+        let pool = create_database_pool().await.unwrap();
+        let mut transaction = pool.begin().await.unwrap();
+
+        let revision_id: i32 = 30672;
+        let entity_id: i32 = 1855;
+
+        sqlx::query!("UPDATE uuid SET trashed = 1 WHERE id = ?", revision_id)
+            .execute(&mut transaction)
+            .await
+            .unwrap();
+
+        let entity = Entity::fetch_via_transaction(entity_id, &mut transaction)
+            .await
+            .unwrap();
+        assert_eq!(entity.trashed, false);
+    }
+
+    #[actix_rt::test]
     async fn checkout_checked_out_revision() {
         let pool = create_database_pool().await.unwrap();
         let mut transaction = pool.begin().await.unwrap();

--- a/src/uuid/model/entity/mod.rs
+++ b/src/uuid/model/entity/mod.rs
@@ -479,16 +479,7 @@ impl Entity {
                     return Err(EntityCheckoutRevisionError::RevisionAlreadyCheckedOut);
                 }
 
-                sqlx::query!(
-                    r#"
-                        UPDATE uuid
-                            SET trashed = false
-                            WHERE id = ?
-                    "#,
-                    revision_id
-                )
-                .execute(&mut transaction)
-                .await?;
+                Uuid::set_state(revision_id, false, &mut transaction).await?;
 
                 sqlx::query!(
                     r#"
@@ -611,16 +602,7 @@ impl Entity {
                     return Err(EntityRejectRevisionError::RevisionCurrentlyCheckedOut);
                 }
 
-                sqlx::query!(
-                    r#"
-                        UPDATE uuid
-                            SET trashed = true
-                            WHERE id = ?
-                    "#,
-                    revision_id
-                )
-                .execute(&mut transaction)
-                .await?;
+                Uuid::set_state(revision_id, true, &mut transaction).await?;
 
                 RevisionEventPayload::new(
                     true,
@@ -655,7 +637,7 @@ mod tests {
     };
     use crate::create_database_pool;
     use crate::event::test_helpers::fetch_age_of_newest_event;
-    use crate::uuid::{ConcreteUuid, UuidFetcher};
+    use crate::uuid::{ConcreteUuid, Uuid, UuidFetcher};
 
     #[actix_rt::test]
     async fn checkout_revision() {
@@ -701,8 +683,7 @@ mod tests {
         let revision_id: i32 = 30672;
         let entity_id: i32 = 1855;
 
-        sqlx::query!("UPDATE uuid SET trashed = 1 WHERE id = ?", revision_id)
-            .execute(&mut transaction)
+        Uuid::set_state(revision_id, true, &mut transaction)
             .await
             .unwrap();
 
@@ -771,16 +752,9 @@ mod tests {
         let pool = create_database_pool().await.unwrap();
         let mut transaction = pool.begin().await.unwrap();
 
-        sqlx::query!(
-            r#"
-                UPDATE uuid
-                    SET trashed = true
-                    WHERE id = 30672
-            "#
-        )
-        .execute(&mut transaction)
-        .await
-        .unwrap();
+        Uuid::set_state(30672, true, &mut transaction)
+            .await
+            .unwrap();
 
         let result = Entity::reject_revision(
             EntityRejectRevisionPayload {


### PR DESCRIPTION
* Add Uuid::set_state() to remove code duplication in setting the `trashed` value of an uuid
* Add a test to make sure, that checkout_revision sets the `trashed` value of a revision to `false` (see #102 -> the bug is due to a missing cache mutation in the API)