### PR TITLE
Reject trashing of revisions via SetStateMutation

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -310,7 +310,7 @@
           "type_info": {
             "type": "Blob",
             "flags": {
-              "bits": 4121
+              "bits": 4113
             },
             "char_set": 224,
             "max_size": 4294967295
@@ -753,7 +753,7 @@
           "type_info": {
             "type": "Blob",
             "flags": {
-              "bits": 24
+              "bits": 16
             },
             "char_set": 224,
             "max_size": 262140
@@ -1094,18 +1094,8 @@
       "nullable": []
     }
   },
-  "769713eded2a80cb23fd93a3767bc1aa4cbc7446e97f4f87d595e922fd143841": {
-    "query": "\n                INSERT INTO event_log (actor_id, event_id, uuid_id, instance_id, date)\n                    SELECT ?, id, ?, ?, ?\n                    FROM event\n                    WHERE name = ?\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 5
-      },
-      "nullable": []
-    }
-  },
-  "778d1aadfabd36aae4aabf449a61958b23a6f7f4b8c25844adcdd064acf7681a": {
-    "query": "\n                    SELECT u.trashed, i.subdomain\n                        FROM uuid u\n                        JOIN (\n                        SELECT id, instance_id FROM attachment_container\n                        UNION ALL\n                        SELECT id, instance_id FROM blog_post\n                        UNION ALL\n                        SELECT id, instance_id FROM comment\n                        UNION ALL\n                        SELECT id, instance_id FROM entity\n                        UNION ALL\n                        SELECT er.id, e.instance_id FROM entity_revision er JOIN entity e ON er.repository_id = e.id\n                        UNION ALL\n                        SELECT id, instance_id FROM page_repository\n                        UNION ALL\n                        SELECT pr.id, p.instance_id FROM page_revision pr JOIN page_repository p ON pr.page_repository_id = p.id\n                        UNION ALL\n                        SELECT id, instance_id FROM term) c ON c.id = u.id\n                        JOIN instance i ON i.id = c.instance_id\n                        WHERE u.id = ? AND discriminator != 'user'\n                ",
+  "7691e4f0280fd0bb9b0f2cc23d9ac8eeeed4a6c35d1a819d6f6f2c8ac45afcca": {
+    "query": "\n                    SELECT u.trashed, i.subdomain, u.discriminator\n                        FROM uuid u\n                        JOIN (\n                        SELECT id, instance_id FROM attachment_container\n                        UNION ALL\n                        SELECT id, instance_id FROM blog_post\n                        UNION ALL\n                        SELECT id, instance_id FROM comment\n                        UNION ALL\n                        SELECT id, instance_id FROM entity\n                        UNION ALL\n                        SELECT er.id, e.instance_id FROM entity_revision er JOIN entity e ON er.repository_id = e.id\n                        UNION ALL\n                        SELECT id, instance_id FROM page_repository\n                        UNION ALL\n                        SELECT pr.id, p.instance_id FROM page_revision pr JOIN page_repository p ON pr.page_repository_id = p.id\n                        UNION ALL\n                        SELECT id, instance_id FROM term) c ON c.id = u.id\n                        JOIN instance i ON i.id = c.instance_id\n                        WHERE u.id = ?\n                ",
     "describe": {
       "columns": [
         {
@@ -1131,6 +1121,18 @@
             "char_set": 224,
             "max_size": 40
           }
+        },
+        {
+          "ordinal": 2,
+          "name": "discriminator",
+          "type_info": {
+            "type": "VarString",
+            "flags": {
+              "bits": 4105
+            },
+            "char_set": 224,
+            "max_size": 180
+          }
         }
       ],
       "parameters": {
@@ -1138,8 +1140,19 @@
       },
       "nullable": [
         false,
+        false,
         false
       ]
+    }
+  },
+  "769713eded2a80cb23fd93a3767bc1aa4cbc7446e97f4f87d595e922fd143841": {
+    "query": "\n                INSERT INTO event_log (actor_id, event_id, uuid_id, instance_id, date)\n                    SELECT ?, id, ?, ?, ?\n                    FROM event\n                    WHERE name = ?\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 5
+      },
+      "nullable": []
     }
   },
   "82e05bbc646bebf37b97af3f23e8599937749cb7ecf4b03bfd079ec152651862": {
@@ -1385,7 +1398,7 @@
           "type_info": {
             "type": "Blob",
             "flags": {
-              "bits": 4120
+              "bits": 4112
             },
             "char_set": 224,
             "max_size": 4294967295
@@ -1397,7 +1410,7 @@
           "type_info": {
             "type": "Blob",
             "flags": {
-              "bits": 4120
+              "bits": 4112
             },
             "char_set": 224,
             "max_size": 4294967295
@@ -2020,7 +2033,7 @@
           "type_info": {
             "type": "Blob",
             "flags": {
-              "bits": 4121
+              "bits": 4113
             },
             "char_set": 224,
             "max_size": 4294967295

--- a/src/uuid/messages.rs
+++ b/src/uuid/messages.rs
@@ -103,6 +103,7 @@ impl MessageResponder for UuidSetStateMutation {
                     SetUuidStateError::EventError { .. } => {
                         HttpResponse::InternalServerError().finish()
                     }
+                    SetUuidStateError::UuidCannotBeTrashed => HttpResponse::BadRequest().finish(),
                 }
             }
         }

--- a/src/uuid/messages.rs
+++ b/src/uuid/messages.rs
@@ -110,14 +110,10 @@ impl MessageResponder for UuidSetStateMutation {
                     SetUuidStateError::EventError { .. } => {
                         HttpResponse::InternalServerError().finish()
                     }
-                    SetUuidStateError::UuidCannotBeTrashed { id, discriminator } => HttpResponse::BadRequest()
+                    SetUuidStateError::UuidCannotBeTrashed { reason } => HttpResponse::BadRequest()
                         .json(UuidSetUuidStateResult {
                             success: false,
-                            reason: Some(format!(
-                                "uuid {} with type \"{}\" cannot be deleted via a setState mutation",
-                                id,
-                                discriminator
-                            )),
+                            reason: Some(reason),
                         }),
                 }
             }

--- a/src/uuid/messages.rs
+++ b/src/uuid/messages.rs
@@ -77,6 +77,13 @@ pub struct UuidSetStateMutation {
     pub trashed: bool,
 }
 
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UuidSetUuidStateResult {
+    pub success: bool,
+    pub reason: Option<String>,
+}
+
 #[async_trait]
 impl MessageResponder for UuidSetStateMutation {
     #[allow(clippy::async_yields_async)]
@@ -103,7 +110,15 @@ impl MessageResponder for UuidSetStateMutation {
                     SetUuidStateError::EventError { .. } => {
                         HttpResponse::InternalServerError().finish()
                     }
-                    SetUuidStateError::UuidCannotBeTrashed => HttpResponse::BadRequest().finish(),
+                    SetUuidStateError::UuidCannotBeTrashed { id, discriminator } => HttpResponse::BadRequest()
+                        .json(UuidSetUuidStateResult {
+                            success: false,
+                            reason: Some(format!(
+                                "uuid {} with type \"{}\" cannot be deleted via a setState mutation",
+                                id,
+                                discriminator
+                            )),
+                        }),
                 }
             }
         }

--- a/src/uuid/model/uuid.rs
+++ b/src/uuid/model/uuid.rs
@@ -411,36 +411,4 @@ mod tests {
             .unwrap();
         assert!(duration > Duration::minutes(1));
     }
-
-    #[actix_rt::test]
-    async fn set_uuid_state_for_untrashable_uuids_fails() {
-        for discriminator in ["entityRevision", "user"].iter() {
-            let pool = create_database_pool().await.unwrap();
-            let mut transaction = pool.begin().await.unwrap();
-
-            let revision_id = sqlx::query!(
-                r#"
-                select id from uuid where discriminator = ?
-                                    and trashed = false
-            "#,
-                discriminator
-            )
-            .fetch_one(&mut transaction)
-            .await
-            .unwrap()
-            .id as i32;
-
-            let result = Uuid::set_uuid_state(
-                SetUuidStatePayload {
-                    ids: vec![revision_id],
-                    user_id: 1,
-                    trashed: true,
-                },
-                &mut transaction,
-            )
-            .await;
-
-            assert!(result.is_err(), "discriminator: {}", discriminator)
-        }
-    }
 }

--- a/src/uuid/model/uuid.rs
+++ b/src/uuid/model/uuid.rs
@@ -220,8 +220,8 @@ pub enum SetUuidStateError {
     DatabaseError { inner: sqlx::Error },
     #[error("UUID state cannot be set because of an internal error: {inner:?}.")]
     EventError { inner: EventError },
-    #[error("UUID {id:?} has a type which cannot be trashed")]
-    UuidCannotBeTrashed { id: i32, discriminator: String },
+    #[error("{reason:?}")]
+    UuidCannotBeTrashed { reason: String },
 }
 
 impl From<sqlx::Error> for SetUuidStateError {
@@ -282,8 +282,11 @@ impl Uuid {
                 Ok(uuid) => {
                     if uuid.discriminator == "entityRevision" || uuid.discriminator == "user" {
                         return Err(SetUuidStateError::UuidCannotBeTrashed {
-                            id,
-                            discriminator: uuid.discriminator,
+                            reason: format!(
+                                "uuid {} with type \"{}\" cannot be deleted via a setState mutation",
+                                id,
+                                uuid.discriminator
+                            ),
                         });
                     }
 

--- a/src/uuid/model/uuid.rs
+++ b/src/uuid/model/uuid.rs
@@ -220,8 +220,8 @@ pub enum SetUuidStateError {
     DatabaseError { inner: sqlx::Error },
     #[error("UUID state cannot be set because of an internal error: {inner:?}.")]
     EventError { inner: EventError },
-    #[error("UUID has a type which cannot be trashed")]
-    UuidCannotBeTrashed,
+    #[error("UUID {id:?} has a type which cannot be trashed")]
+    UuidCannotBeTrashed { id: i32, discriminator: String },
 }
 
 impl From<sqlx::Error> for SetUuidStateError {
@@ -281,7 +281,10 @@ impl Uuid {
             let instance: Instance = match result {
                 Ok(uuid) => {
                     if uuid.discriminator == "entityRevision" || uuid.discriminator == "user" {
-                        return Err(SetUuidStateError::UuidCannotBeTrashed);
+                        return Err(SetUuidStateError::UuidCannotBeTrashed {
+                            id,
+                            discriminator: uuid.discriminator,
+                        });
                     }
 
                     // UUID has already the correct state, skip

--- a/tests/set-uuid-state.rs
+++ b/tests/set-uuid-state.rs
@@ -24,8 +24,6 @@ mod tests {
             .unwrap()
             .id as i32;
 
-            dbg!(revision_id);
-
             let req = test::TestRequest::post()
                 .uri("/")
                 .set_json(&UuidMessage::UuidSetStateMutation(UuidSetStateMutation {

--- a/tests/set-uuid-state.rs
+++ b/tests/set-uuid-state.rs
@@ -1,0 +1,41 @@
+#[cfg(test)]
+mod tests {
+    use actix_web::{test, App};
+
+    use serlo_org_database_layer::uuid::{UuidMessage, UuidSetStateMutation};
+    use serlo_org_database_layer::{configure_app, create_database_pool};
+
+    #[actix_rt::test]
+    async fn set_uuid_state_for_untrashable_uuids_fails() {
+        for discriminator in ["entityRevision", "user"].iter() {
+            let pool = create_database_pool().await.unwrap();
+            let mut transaction = pool.begin().await.unwrap();
+
+            let app = configure_app(App::new(), pool);
+            let mut app = test::init_service(app).await;
+
+            let revision_id = sqlx::query!(
+                "select id from uuid where discriminator = ? and trashed = false",
+                discriminator
+            )
+            .fetch_one(&mut transaction)
+            .await
+            .unwrap()
+            .id as i32;
+
+            dbg!(revision_id);
+
+            let req = test::TestRequest::post()
+                .uri("/")
+                .set_json(&UuidMessage::UuidSetStateMutation(UuidSetStateMutation {
+                    ids: vec![revision_id],
+                    user_id: 1,
+                    trashed: true,
+                }))
+                .to_request();
+            let resp = test::call_service(&mut app, req).await;
+
+            assert_eq!(resp.status(), 400);
+        }
+    }
+}


### PR DESCRIPTION
Closes #100 (With the current change the API would throw an `INTERNAL_SERVER_ERROR` since the setUuidState() func has `expectedStatusCodes: [200]`. I'll change the implementation there in a follow up PR so that a `UserInputError()` will be thrown.

@inyono I have a question: All tests pass, however I get an error, when I let the build run locally and I make the request:

```
In [3]: db_layer.set_target(db_layer.Targets.LOCAL)
In [4]: db_layer.fetch("UuidSetStateMutation", { "ids": [1], "userId": 1, "trashed": True })
```

Here I get the error:

```
   Compiling serlo-org-database-layer v0.3.13 (/home/kulla/workspace/serlo/database-layer)
    Finished dev [unoptimized + debuginfo] target(s) in 11.28s
     Running `target/debug/serlo-org-database-layer`
🚀 Server ready: http://localhost:8080
/set-uuid-state: UuidCannotBeTrashed { reason: "uuid 1 with type \"user\" cannot be deleted via a setState mutation" }
thread 'actix-rt|system:0|arbiter:0' panicked at 'assertion failed: self.remaining() >= dst.len()', /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/bytes-1.0.1/src/buf/buf_impl.rs:250:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/2fd73fabe469357a12c2c974c140f67e7cdd76d0/library/std/src/panicking.rs:493:5
   1: core::panicking::panic_fmt
             at /rustc/2fd73fabe469357a12c2c974c140f67e7cdd76d0/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/2fd73fabe469357a12c2c974c140f67e7cdd76d0/library/core/src/panicking.rs:50:5
   3: bytes::buf::buf_impl::Buf::copy_to_slice
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/bytes-1.0.1/src/buf/buf_impl.rs:250:9
   4: bytes::buf::buf_impl::Buf::get_u64_le
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/bytes-1.0.1/src/buf/buf_impl.rs:511:9
   5: <bytes::bytes::Bytes as sqlx_core::mysql::io::buf::MySqlBufExt>::get_uint_lenenc
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/sqlx-core-0.5.5/src/mysql/io/buf.rs:25:21
   6: sqlx_core::mysql::connection::stream::MySqlStream::skip_result_metadata::{{closure}}
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/sqlx-core-0.5.5/src/mysql/connection/stream.rs:185:32
   7: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /home/kulla/.local/share/asdf/installs/rust/stable/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/mod.rs:80:19
   8: sqlx_core::mysql::connection::stream::MySqlStream::wait_until_ready::{{closure}}
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/sqlx-core-0.5.5/src/mysql/connection/stream.rs:109:21
   9: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /home/kulla/.local/share/asdf/installs/rust/stable/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/mod.rs:80:19
  10: <sqlx_core::mysql::connection::MySqlConnection as sqlx_core::connection::Connection>::ping::{{closure}}
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/sqlx-core-0.5.5/src/mysql/connection/mod.rs:61:13
  11: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /home/kulla/.local/share/asdf/installs/rust/stable/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/mod.rs:80:19
  12: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /home/kulla/.local/share/asdf/installs/rust/stable/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:119:9
  13: <sqlx_core::pool::connection::PoolConnection<DB> as core::ops::drop::Drop>::drop::{{closure}}
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/sqlx-core-0.5.5/src/pool/connection.rs:83:33
  14: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /home/kulla/.local/share/asdf/installs/rust/stable/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/mod.rs:80:19
  15: tokio::runtime::task::core::CoreStage<T>::poll::{{closure}}
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/task/core.rs:235:17
  16: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/loom/std/unsafe_cell.rs:14:9
  17: tokio::runtime::task::core::CoreStage<T>::poll
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/task/core.rs:225:13
  18: tokio::runtime::task::harness::poll_future::{{closure}}
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/task/harness.rs:422:23
  19: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /home/kulla/.local/share/asdf/installs/rust/stable/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:344:9
  20: std::panicking::try::do_call
             at /home/kulla/.local/share/asdf/installs/rust/stable/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:379:40
  21: __rust_try
  22: std::panicking::try
             at /home/kulla/.local/share/asdf/installs/rust/stable/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:343:19
  23: std::panic::catch_unwind
             at /home/kulla/.local/share/asdf/installs/rust/stable/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:431:14
  24: tokio::runtime::task::harness::poll_future
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/task/harness.rs:409:19
  25: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/task/harness.rs:89:9
  26: tokio::runtime::task::harness::Harness<T,S>::poll
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/task/harness.rs:59:15
  27: tokio::runtime::task::raw::poll
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/task/raw.rs:104:5
  28: tokio::runtime::task::raw::RawTask::poll
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/task/raw.rs:66:18
  29: tokio::runtime::task::Notified<S>::run
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/task/mod.rs:171:9
  30: tokio::runtime::basic_scheduler::Inner<P>::block_on::{{closure}}::{{closure}}
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/basic_scheduler.rs:254:73
  31: tokio::coop::with_budget::{{closure}}
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/coop.rs:106:9
  32: std::thread::local::LocalKey<T>::try_with
             at /home/kulla/.local/share/asdf/installs/rust/stable/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:272:16
  33: std::thread::local::LocalKey<T>::with
             at /home/kulla/.local/share/asdf/installs/rust/stable/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:248:9
  34: tokio::coop::with_budget
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/coop.rs:99:5
  35: tokio::coop::budget
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/coop.rs:76:5
  36: tokio::runtime::basic_scheduler::Inner<P>::block_on::{{closure}}
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/basic_scheduler.rs:254:50
  37: tokio::runtime::basic_scheduler::enter::{{closure}}
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/basic_scheduler.rs:323:29
  38: tokio::macros::scoped_tls::ScopedKey<T>::set
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/macros/scoped_tls.rs:61:9
  39: tokio::runtime::basic_scheduler::enter
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/basic_scheduler.rs:323:5
  40: tokio::runtime::basic_scheduler::Inner<P>::block_on
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/basic_scheduler.rs:202:9
  41: tokio::runtime::basic_scheduler::InnerGuard<P>::block_on
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/basic_scheduler.rs:481:9
  42: tokio::runtime::basic_scheduler::BasicScheduler<P>::block_on
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/basic_scheduler.rs:162:24
  43: tokio::runtime::Runtime::block_on
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/runtime/mod.rs:450:46
  44: tokio::task::local::LocalSet::block_on
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/tokio-1.6.1/src/task/local.rs:459:9
  45: actix_rt::runtime::Runtime::block_on
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/actix-rt-2.2.0/src/runtime.rs:85:9
  46: actix_rt::arbiter::Arbiter::with_tokio_rt::{{closure}}
             at /home/kulla/.local/share/asdf/installs/rust/stable/registry/src/github.com-1ecc6299db9ec823/actix-rt-2.2.0/src/arbiter.rs:145:21
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

Do you have a clue why this happens?