### PR TITLE
Remove AliasError

### DIFF
--- a/server/src/alias/messages.rs
+++ b/server/src/alias/messages.rs
@@ -2,7 +2,7 @@ use actix_web::HttpResponse;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use super::model::{fetch, fetch_via_transaction, AliasError};
+use super::model::{fetch, fetch_via_transaction};
 use crate::database::Connection;
 use crate::instance::Instance;
 use crate::message::MessageResponder;
@@ -56,20 +56,6 @@ pub mod alias_query {
                     fetch_via_transaction(path, instance, transaction).await?
                 }
             })
-        }
-    }
-
-    impl From<AliasError> for operation::Error {
-        fn from(error: AliasError) -> Self {
-            match error {
-                AliasError::DatabaseError { inner } => operation::Error::InternalServerError {
-                    error: Box::new(inner),
-                },
-                AliasError::InvalidInstance => operation::Error::InternalServerError {
-                    error: Box::new(error),
-                },
-                AliasError::LegacyRoute | AliasError::NotFound => operation::Error::NotFoundError,
-            }
         }
     }
 }

--- a/server/src/operation.rs
+++ b/server/src/operation.rs
@@ -18,8 +18,11 @@ pub enum Error {
 
 impl From<sqlx::Error> for Error {
     fn from(error: sqlx::Error) -> Self {
-        Error::InternalServerError {
-            error: Box::new(error),
+        match error {
+            sqlx::Error::RowNotFound => Error::NotFoundError,
+            _ => Error::InternalServerError {
+                error: Box::new(error),
+            },
         }
     }
 }


### PR DESCRIPTION
After looking into the source code I found that `AliasError` can be
directly replaced with with the new type `operation::Error` since this error
type includes all necessary information necessary to handle an alias
query. Only when more fine grained information are necessary we should
include other error types.