### PR TITLE
Add PageAddRevisionMutation

### DIFF
--- a/server/src/uuid/model/page/messages.rs
+++ b/server/src/uuid/model/page/messages.rs
@@ -73,7 +73,7 @@ impl MessageResponder for PageAddRevisionMutation {
                     page_revision_id: Some(data.id),
                 }),
             Err(error) => {
-                println!("/add-revision: {:?}", error);
+                println!("/page-add-revision: {:?}", error);
                 match error {
                     PageAddRevisionError::DatabaseError { .. } => {
                         HttpResponse::InternalServerError().finish()
@@ -86,6 +86,9 @@ impl MessageResponder for PageAddRevisionMutation {
                             success: false,
                             reason: Some("no page found for provided pageId".to_string()),
                         })
+                    }
+                    PageAddRevisionError::CheckoutRevisionError { .. } => {
+                        HttpResponse::InternalServerError().finish()
                     }
                 }
             }

--- a/server/tests/page.rs
+++ b/server/tests/page.rs
@@ -1,0 +1,35 @@
+#[cfg(test)]
+mod add_revision_mutation {
+    use test_utils::*;
+
+    #[actix_rt::test]
+    async fn adds_revision() {
+        let mut transaction = begin_transaction().await;
+
+        let mutation_response = Message::new(
+            "PageAddRevisionMutation",
+            json!({
+                "pageId": 16256,
+                "content": "test content",
+                "title": "test title",
+                "userId": 1,
+            }),
+        )
+        .execute_on(&mut transaction)
+        .await;
+
+        let query_response = Message::new(
+            "UuidQuery",
+            json!({ "id": get_json(mutation_response).await["pageRevisionId"] }),
+        )
+        .execute_on(&mut transaction)
+        .await;
+
+        assert_ok_with(query_response, |result| {
+            assert_eq!(result["content"], "test content");
+            assert_eq!(result["title"], "test title");
+            assert_eq!(result["authorId"], 1 as i32);
+        })
+        .await;
+    }
+}

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1862,6 +1862,16 @@
       ]
     }
   },
+  "b06a90ba7abee0f9ef7b237142448f14413a129a647debe16df0a03ba2066b82": {
+    "query": "\n                INSERT INTO uuid (trashed, discriminator)\n                    VALUES (0, 'pageRevision')\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 0
+      },
+      "nullable": []
+    }
+  },
   "b67a6cd1168e030043fc309da009c241d88b7543ce11598b7e183086dd2f5077": {
     "query": "\n                SELECT entity_id\n                    FROM term_taxonomy_entity\n                    WHERE term_taxonomy_id = ?\n                    ORDER BY position ASC\n            ",
     "describe": {
@@ -2706,6 +2716,16 @@
       "columns": [],
       "parameters": {
         "Right": 2
+      },
+      "nullable": []
+    }
+  },
+  "fb7a566e9ea371a8e210e88cec9d3e4cf0832ccc6706c7a164275bd43d86f596": {
+    "query": "\n                INSERT INTO page_revision (id, author_id, page_repository_id, title, content)\n                    VALUES (?, ?, ?, ?, ?)\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 5
       },
       "nullable": []
     }


### PR DESCRIPTION
- feat(entity): add basic implementation of EntityAddRevisionMutation
- test(entity-add-revision): test creation of revision
- feat(entity-add-revision): validate if entity exists
- feat(entity-add-revision): handle needsReview parameter
- refactor(subscription): make fetch_subscription_by_user_and_object public
- feat(entity-add-revision): handle subscribeThis and subscribeThisByEmail
- feat(entity-add-revision): subscribe also to the entity
- refactor(entity-add-revision): give empty reason to checkout
- refactor(entity-add-revision): remove subscription of revision, that
- feat(event): implement CreateEntityRevisionEvent and use it in
- refactor(entity-add-revision): fill entity_revision_field in just one
- refactor(entity-revision-event): ignore entity revision id
- refactor(entity-add-revision): move entity revision adding logic to
- refactor(entity-add-revision): small fix after refactor 2c4d22d
- refactor(subscriptions): put fetch_subscription_by_user_and_object
- test(entity-add-revision): prefer to fetch revision using ORDER BY
- refactor(entity-add-revision): map errors for checking entity exists
- refactor(entity-add-revision): fit EntityAddRevisionPayload to communicate with api
- Fix by linter
- refactor(entity-add-revision): remove unnecessary decorators
- test(entity-add-revision): try to fix CI-CD 'Deadlock found' error
- feat(entity-add-revision): fill fields according to each revision type
- refactor(entity-add-revision): do not handle DatabaseError and remove
- refactor(entity-add-revision): implement fields param in payload
- test(entity-add-revision): start writing integration tests
- refactor(entity-add-revision): be sure to store field as snake case
- test(entity-add-revision): complete integration tests
- feat(page): implement addRevision mutation
- refactor(page-add-revision): checkout revision after adding it
