### PR TITLE
Rename job of pact tests in github worflow

### DIFF
--- a/.github/workflows/pacts.yml
+++ b/.github/workflows/pacts.yml
@@ -2,7 +2,7 @@ name: Pacts
 on:
   pull_request:
 jobs:
-  test:
+  pacts_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
`test` is already used for the unit tests and this prevents conflicts