### PR TITLE
Unpin pact consumer version

### DIFF
--- a/__tests-pacts__/pacts.js
+++ b/__tests-pacts__/pacts.js
@@ -42,7 +42,6 @@ test('Pacts', async () => {
     provider: 'serlo.org-database-layer',
     providerVersion,
     providerBaseUrl: 'http://localhost:8080',
-    consumerVersionTag: '0.29.1-b68d211',
     pactBrokerUrl: 'https://pact.serlo.org',
     pactBrokerUsername: process.env.PACT_BROKER_USERNAME,
     pactBrokerPassword: process.env.PACT_BROKER_PASSWORD,


### PR DESCRIPTION
The consumer version was pinnend when some mutations weren't implemented.
Now, these and some other endpoints were implementend and we are not pact testing them.
