### PR TITLE
fix: Saving course page revisions without an icon

### DIFF
--- a/server/src/uuid/model/entity/mod.rs
+++ b/server/src/uuid/model/entity/mod.rs
@@ -484,6 +484,13 @@ impl Entity {
                 last_revision_fields.insert("cohesive".to_string(), "false".to_string());
             }
 
+            // FIXME: Do we need to fix this in the frontend?!
+            if payload.revision_type == EntityRevisionType::CoursePage
+                && !fields.contains_key("icon")
+            {
+                fields.insert("icon".to_string(), "book-open".to_string());
+            }
+
             if last_revision_fields == fields {
                 return Ok(
                     EntityRevision::fetch_via_transaction(revision_id, &mut transaction).await?,

--- a/server/tests/entity.rs
+++ b/server/tests/entity.rs
@@ -144,6 +144,38 @@ mod add_revision_mutation {
         assert_eq!(exercise_group_revision["id"], new_revision["revisionId"]);
     }
 
+    #[actix_rt::test]
+    async fn does_not_add_revision_if_course_page_has_icon() {
+        let revision = Message::new("UuidQuery", json!({ "id": 31315 }))
+            .execute()
+            .await
+            .get_json();
+
+        let new_revision = Message::new(
+            "EntityAddRevisionMutation",
+            json!({
+                "revisionType": "CoursePageRevision",
+                "input": {
+                    "changes": "second edit",
+                    "entityId": revision["repositoryId"],
+                    "needsReview": true,
+                    "subscribeThis": false,
+                    "subscribeThisByEmail": false,
+                    "fields": {
+                        "title": revision["title"],
+                        "content": revision["content"]
+                    }
+                },
+                "userId": 1
+            }),
+        )
+        .execute()
+        .await
+        .get_json();
+
+        assert_eq!(revision["id"], new_revision["revisionId"]);
+    }
+
     async fn get_revisions(id: i32, transaction: &mut sqlx::Transaction<'_, sqlx::MySql>) -> Value {
         Message::new("UuidQuery", json!({ "id": id }))
             .execute_on(transaction)


### PR DESCRIPTION
Closes https://github.com/serlo/serlo.org-database-layer/issues/285